### PR TITLE
Update Ice to 3.8.2 and fix README tap instructions

### DIFF
--- a/Casks/icegridgui.rb
+++ b/Casks/icegridgui.rb
@@ -1,6 +1,6 @@
 cask "icegridgui" do
-  version "3.8.1"
-  sha256 "10c6386a4d67a4d5a5c34297159bad97fff7adaa5f50a0977a988d7164614927"
+  version "3.8.2"
+  sha256 "6394eb40c0a17ef3e78ba7c6d42813fc3aef61c9a39f081bfa7b248cd407e716"
 
   url "https://download.zeroc.com/ice/3.8/IceGridGUI-#{version}.dmg"
   name "IceGrid GUI"

--- a/Formula/ice.rb
+++ b/Formula/ice.rb
@@ -1,12 +1,12 @@
 class Ice < Formula
   desc "Comprehensive RPC framework"
   homepage "https://zeroc.com"
-  url "https://github.com/zeroc-ice/ice/archive/v3.8.1.tar.gz"
-  sha256 "87aa0381f2347715467686547bccf253fa208948bf2a462584872d2d0f8b1720"
+  url "https://github.com/zeroc-ice/ice/archive/v3.8.2.tar.gz"
+  sha256 "d350ebbcdd7971fafccebfdf1e99db139dc6d121f5a5dcdc4036256206735078"
 
   bottle do
     root_url "https://download.zeroc.com/ice/3.8"
-    sha256 cellar: :any, arm64_tahoe: "c8ca096b86cc3658b57da43658d0c1aae4406ac713b421d7fa6dc4aff1891cb5"
+    sha256 cellar: :any, arm64_tahoe: "01103d6b9219e76b6276aab1c7541bdb259928aaeefa41ca82e8d6e315acc0f0"
   end
 
   depends_on "lmdb"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository is a [Homebrew tap](https://docs.brew.sh/Taps) which contains fo
 To add this tap to Homebrew:
 
 ```shell
-brew trust zeroc-ice/tap
 brew tap zeroc-ice/tap
+brew trust zeroc-ice/tap
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository is a [Homebrew tap](https://docs.brew.sh/Taps) which contains fo
 To add this tap to Homebrew:
 
 ```shell
+brew trust zeroc-ice/tap
 brew tap zeroc-ice/tap
 ```
 


### PR DESCRIPTION
- Bump ice formula and icegridgui cask to 3.8.2 with new checksums
- Add `brew trust` step to README tap setup instructions
