### PR TITLE
Make ice@3.8 a real formula so versioned installs pass tap trust

### DIFF
--- a/Aliases/ice@3.8
+++ b/Aliases/ice@3.8
@@ -1,1 +1,0 @@
-../Formula/ice.rb

--- a/Formula/ice@3.8.rb
+++ b/Formula/ice@3.8.rb
@@ -1,0 +1,72 @@
+class IceAT38 < Formula
+  desc "Comprehensive RPC framework"
+  homepage "https://zeroc.com"
+  url "https://github.com/zeroc-ice/ice/archive/v3.8.2.tar.gz"
+  sha256 "d350ebbcdd7971fafccebfdf1e99db139dc6d121f5a5dcdc4036256206735078"
+
+  bottle do
+    root_url "https://download.zeroc.com/ice/3.8"
+    sha256 cellar: :any, arm64_tahoe: "01103d6b9219e76b6276aab1c7541bdb259928aaeefa41ca82e8d6e315acc0f0"
+    sha256 cellar: :any, arm64_sequoia: "240aef8fa07f3eec7bad82741b6a297092bdde2ceeeae665242e9b7ea01bcadb"
+  end
+
+  depends_on "lmdb"
+  depends_on "mcpp"
+
+  def install
+    args = [
+      "prefix=#{prefix}",
+      "V=1",
+      "USR_DIR_INSTALL=yes", # ensure slice and man files are installed to share
+      "MCPP_HOME=#{Formula["mcpp"].opt_prefix}",
+      "LMDB_HOME=#{Formula["lmdb"].opt_prefix}",
+      "CONFIGS=all",
+      "PLATFORMS=all",
+      "LANGUAGES=cpp",
+    ]
+    system "make", "install", *args
+
+    (libexec/"bin").mkpath
+    mv bin/"slice2py", libexec/"bin"
+  end
+
+  test do
+    (testpath / "Hello.ice").write <<~EOS
+      module Test
+      {
+          interface Hello
+          {
+              void sayHello();
+          }
+      }
+    EOS
+
+    port = free_port
+
+    (testpath / "Test.cpp").write <<~CPP
+      #include "Hello.h"
+      #include <Ice/Ice.h>
+
+      class HelloI : public Test::Hello
+      {
+      public:
+          void sayHello(const Ice::Current&) override {}
+      };
+
+      int main(int argc, char* argv[])
+      {
+        Ice::CommunicatorHolder ich(argc, argv);
+        auto adapter = ich->createObjectAdapterWithEndpoints("Hello", "default -h 127.0.0.1 -p #{port}");
+        adapter->add(std::make_shared<HelloI>(), Ice::stringToIdentity("hello"));
+        adapter->activate();
+        return 0;
+      }
+    CPP
+
+    system "#{bin}/slice2cpp", "Hello.ice"
+    system ENV.cxx, "-std=c++20", "-c", "-I#{include}", "Hello.cpp"
+    system ENV.cxx, "-std=c++20", "-c", "-I#{include}", "Test.cpp"
+    system ENV.cxx, "-L#{lib}", "-o", "test", "Test.o", "Hello.o", "-lIce", "-lpthread"
+    system "./test"
+  end
+end


### PR DESCRIPTION
On a fresh machine `brew install zeroc-ice/tap/ice@3.8` fails with `Refusing to load formula zeroc-ice/tap/ice from untrusted tap`, because `ice@3.8` is a symlink alias to `Formula/ice.rb` rather than a real formula file. `brew install` auto-trusts a fully-qualified `user/tap/formula` argument only when the typed name matches a file under `Formula/`; an alias name isn't in `formula_files_by_name`, so nothing gets trusted and the resolved `ice` formula is then refused. `ice@3.7` and the nightly `ice@3.9` don't hit this because they're real formula files. This is what's currently breaking the ice-demos 3.8 macOS CI, which installs Ice with exactly that command. See #16.

This replaces the `Aliases/ice@3.8` symlink with a real `Formula/ice@3.8.rb`, identical to `Formula/ice.rb` except for the versioned class name, mirroring how `Formula/ice@3.7.rb` already exists. I confirmed locally that `brew install zeroc-ice/tap/ice@3.8` then prints `==> Trusted formula zeroc-ice/tap/ice@3.8` and proceeds.

Left as a draft because the versioned formula needs its own bottles: a real `ice@3.8` formula looks for `ice@3.8-<version>.<tag>.bottle.tar.gz`, which isn't published yet (only the `ice-…` bottles exist), so the bottle block here still carries the `ice` sha256s as a placeholder. The release pipeline needs to publish `ice@3.8`-named bottles and update these sha256s before merging, the same way `ice@3.7` bottles are published.
