### PR TITLE
Pin GitHub Actions to SHAs and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directories: ["/", "/.github/actions/*"]
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup tap
         uses: ./.github/actions/setup-tap

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
       formulae: ${{ steps.changed.outputs.formulae }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # On PRs, only build formulae that were modified.
       # On push to main, build all formulae.
@@ -54,7 +54,7 @@ jobs:
         os: [macos-15, macos-26]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup tap
         uses: ./.github/actions/setup-tap


### PR DESCRIPTION
Pins every third-party GitHub Action to a full commit SHA (with the version in a trailing comment) and adds a Dependabot config to keep those pins current, matching the setup used across the other repos.

- Pins all actions in the workflows and the composite action under `.github/actions/` so a moved tag can't change what CI runs.
- Adds a `github-actions` Dependabot block scanning both workflows and the composite action (`directories: ["/", "/.github/actions/*"]`): monthly schedule, 7-day cooldown, and a single catch-all group so updates arrive as one PR.
